### PR TITLE
Refactored to use load functions

### DIFF
--- a/WloWiki/src/lib/data/api.ts
+++ b/WloWiki/src/lib/data/api.ts
@@ -1,7 +1,7 @@
 import type { State } from '@vincjo/datatables/remote';
 
-export const reload = async (state: State, type: String) => {
-	const response = await fetch(`/api/${type}?${getParams(state)}`);
+export const reload = async (state: State, type: String, providedFetch?: any) => {
+	const response = await providedFetch ? providedFetch(`/internalapi/${type}?${getParams(state)}`) : fetch(`/internalapi/${type}?${getParams(state)}`);
 	return response.json();
 };
 

--- a/WloWiki/src/routes/equipment/+page.svelte
+++ b/WloWiki/src/routes/equipment/+page.svelte
@@ -1,11 +1,11 @@
 <script>
 	import Datatable from './Datatable.svelte';
 	export let data
-	console.log(data)
+	console.log(data);
 
 	
 </script>
 
 
 
-<Datatable />
+<Datatable initialEquipments={data.equipments} />

--- a/WloWiki/src/routes/equipment/+page.ts
+++ b/WloWiki/src/routes/equipment/+page.ts
@@ -1,0 +1,9 @@
+import { reload } from '$lib/data/api';
+import type { State } from '@vincjo/datatables/local';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch }) => {
+	return {
+        equipments: await reload({pageNumber: 0} as State, "equipment", fetch)
+	};
+};

--- a/WloWiki/src/routes/equipment/Datatable.svelte
+++ b/WloWiki/src/routes/equipment/Datatable.svelte
@@ -13,12 +13,12 @@
 
     import { reload } from '$lib/data/api'
 
+    export let initialEquipments: Array<Row> = [];
     
-    const handler = new DataHandler<Row>([], { rowsPerPage: 15, totalRows: 9999});
+    const handler = new DataHandler<Row>(initialEquipments, { rowsPerPage: 15, totalRows: 9999});
     const rows = handler.getRows();
 
     handler.onChange((state: State) => reload(state, "items"));
-    handler.invalidate();
 
     function getImagePath(name: string) {
 		const formattedName = name.toLowerCase().replace(/ /g, '_');

--- a/WloWiki/src/routes/internalapi/[type]/+server.ts
+++ b/WloWiki/src/routes/internalapi/[type]/+server.ts
@@ -1,0 +1,6 @@
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url, params }) => {
+	const response = await fetch(`http://localhost:8080/api/${params.type}?${url.searchParams.toString()}`).then(response => response.json());
+	return new Response(response);
+};

--- a/WloWiki/src/routes/materials/+page.svelte
+++ b/WloWiki/src/routes/materials/+page.svelte
@@ -1,11 +1,9 @@
 <script>
     import MaterialDatatable from './MaterialDatatable.svelte';
-	export let data
+	export let data;
 	console.log(data)
 
 	
 </script>
 
-
-
-<MaterialDatatable />
+<MaterialDatatable initialMaterials={data.materials} />

--- a/WloWiki/src/routes/materials/+page.ts
+++ b/WloWiki/src/routes/materials/+page.ts
@@ -1,0 +1,9 @@
+import { reload } from '$lib/data/api';
+import type { State } from '@vincjo/datatables/local';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params, fetch }) => {
+	return {
+        materials: await reload({pageNumber: 0} as State, "materials", fetch)
+	};
+};

--- a/WloWiki/src/routes/materials/MaterialDatatable.svelte
+++ b/WloWiki/src/routes/materials/MaterialDatatable.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
     import Search from '$lib/components/Search.svelte';
-    import ThFilter from '$lib/components/ThFilter.svelte';
-    import ThSort from '$lib/components/ThSort.svelte';
     import RowCount from '$lib/components/RowCount.svelte';
     import RowsPerPage from '$lib/components/RowsPerPage.svelte';
     import Pagination from '$lib/components/Pagination.svelte';
@@ -13,12 +11,12 @@
 
     import { reload } from '$lib/data/api'
 
+    export let initialMaterials: Array<Row> = [];
     
-    const handler = new DataHandler<Row>([], { rowsPerPage: 15, totalRows: 9999});
+    const handler = new DataHandler<Row>(initialMaterials, { rowsPerPage: 15, totalRows: 9999});
     const rows = handler.getRows();
 
     handler.onChange((state: State) => reload(state, "materials"));
-    handler.invalidate();
 
     function getImagePath(name: string) {
 		const formattedName = name.toLowerCase().replace(/ /g, '_');


### PR DESCRIPTION
Alright, I did a lot of things here.
First and foremost, I added the ``/internalapi/[type]`` route with a ``+server.ts``.
This will proxy any get requests to your internal go API running on the same machine under ``http://localhost:8080``. If that's not suitable for your production environment but works in your dev environment you should take a look at https://kit.svelte.dev/docs/modules#$env-dynamic-private to see how you can base the API URL off of environment variables.

Next I added load functions: https://kit.svelte.dev/docs/load
These are pretty nifty, because they allow you to fetch data during ServerSideRendering (SSR) on the server but also during ClientSideRendering (CSR) on the client when switching to different URLs. I've made it so that the load function only returns when the backend data is actually there. You can take a look at https://kit.svelte.dev/docs/load#streaming-with-promises if you don't want to do that and instead want to code your app in a way that has placeholders while the data actually loads.

I also did a little performance trick there that might not work, you'll have to test that: Load functions get their own special implementation of fetch passed in as a parameter by SvelteKit. It'll store the data fetched during SSR in a binary format and send it along to the client, so that the client doesn't have to do a request during hydration.